### PR TITLE
Fix commits array

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -17,14 +17,18 @@ declare -a commits
 
 REACHED_LAST_COMMIT=0
 git clone --shallow-since="$clone_from" https://github.com/Homebrew/homebrew-core.git
-git -C ./homebrew-core log --format='%H' --perl-regexp --author='^(?!BrewTestBot)' -- ./Formula/git.rb ./Formula/g/git.rb | while read -r commit; do
+while read -r commit
+do
   if [[ $REACHED_LAST_COMMIT -gt 0 ]] || [[ "$commit" == "$last_commit" ]]
   then
     REACHED_LAST_COMMIT=1
     continue
   fi
   commits=("$commit" "${commits[@]}")
-done
+done < <(
+  # shellcheck disable=SC2312
+  git -C ./homebrew-core log --format='%H' --perl-regexp --author='^(?!BrewTestBot)' -- ./Formula/git.rb ./Formula/g/git.rb
+)
 
 printf 'Applying commits %s\n' "${commits[*]}"
 


### PR DESCRIPTION
This reverts [1].

It must not run in sub-shells otherwise the commits array is empty
afterwards.

[1] https://github.com/Frederick888/homebrew-git-custom/commit/91d3e9a31d8ab91bf4b9e2ba88010cfd278ef837#diff-7769142444e7e8c796097f6abff89c2ecbd6183fbcf37292b6ad18a88a71b58fR19-R25
